### PR TITLE
Add feature to limit author's books index by max word count

### DIFF
--- a/app/controllers/author_books_controller.rb
+++ b/app/controllers/author_books_controller.rb
@@ -5,6 +5,10 @@ class AuthorBooksController < ApplicationController
     if params[:sorted] == "true" 
       @books = @books.order(:title)
     end
+    if params[:max_word_count] != nil
+      number = params[:max_word_count].delete(",").to_i
+      @books = @books.max_word_count(number)
+    end
   end
 
   def new 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,4 +4,8 @@ class Book < ApplicationRecord
   def self.part_of_series
     self.where(part_of_series: true)
   end
+
+  def self.max_word_count(number)
+    self.select { |book| book.word_count > number }
+  end
 end

--- a/app/views/author_books/index.html.erb
+++ b/app/views/author_books/index.html.erb
@@ -3,6 +3,14 @@
   <li><a href="/books">Book List</a></li>
   <li><a href="/">Return Home</a></li>
 </ul>
+<br><%= button_to "Create Book", "/authors/#{@author.id}/books/new", method: :get %><br>
+<%= button_to "Sort Alphabetically", "/authors/#{@author.id}/books", method: :get, params: {sorted: true} %>
+<br><%= form_with url: "/authors/#{@author.id}/books", method: :get, local: true do |form| %>
+  <%= form.label(:max_word_count, "Only return records with more than") %>
+  <%= form.text_field(:max_word_count) %>
+  <%= "number of words" %>
+  <%= form.submit("Submit") %>
+<% end %><br>
 
 <h1>List of Books by <%= @author.name %></h1>
 
@@ -15,6 +23,3 @@
   <p>Log created: <%= book.created_at %></p>
   <p>Log updated: <%= book.updated_at %></p>
 <% end %>
-
-<%= button_to "Create Book", "/authors/#{@author.id}/books/new", method: :get %><br>
-<%= button_to "Sort Alphabetically", "/authors/#{@author.id}/books", method: :get, params: {sorted: true} %>

--- a/spec/features/authors/books/index_spec.rb
+++ b/spec/features/authors/books/index_spec.rb
@@ -65,6 +65,23 @@ RSpec.describe 'the authors books index page' do
         
         expect(@book_4.title).to appear_before(@book_1.title)
       end
+
+      it "has a form that allows me to limit the number of displayed books by word_count" do 
+        visit "/authors/#{@author_1.id}/books"
+
+        expect(page).to have_content("Only return records with more than")
+        expect(page).to have_field("max_word_count")
+        expect(page).to have_content("words")
+        expect(page).to have_content("#{@book_1.title}")
+
+        fill_in("max_word_count", with: "100,000")
+        click_button("Submit")
+
+        expect(current_path).to eq("/authors/#{@author_1.id}/books")
+        expect(page).to_not have_content("#{@book_1.title}")
+        expect(page).to have_content("#{@book_3.title}")
+        expect(page).to have_content("#{@book_4.title}")
+      end
     end
   end
 end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -15,5 +15,15 @@ RSpec.describe Book do
         expect(Book.part_of_series).to eq([book_1, book_2])
       end
     end
+
+    describe "#max_word_count" do 
+      it "returns a collection of books which are above a given word count" do 
+        author = Author.create!(active: false, dob_year: 1989, name: "Lee Saville", country: "Brazil")
+        book_1 = author.books.create!(part_of_series: true, word_count: 98000, title: "Darkness", genre: "Scifi/Fantasy")
+        book_2 = author.books.create!(part_of_series: false, word_count: 105645, title: "My Go Story", genre: "Non-fiction")  
+
+        expect(Book.max_word_count(100000)).to eq([book_2])
+      end
+    end
   end
 end


### PR DESCRIPTION
Added form to author's books index to limit records shown by a max word count. Still want to add updated conditionals in the author_books_controller to handle sorting AFTER limiting the input and vice versa. Right now if you hit sort after limiting the input it re-shows all of the input. 